### PR TITLE
Allow non-DwC fields to be included in custom download

### DIFF
--- a/grails-app/services/au/org/ala/downloads/BiocacheService.groovy
+++ b/grails-app/services/au/org/ala/downloads/BiocacheService.groovy
@@ -86,7 +86,7 @@ class BiocacheService {
 
         fields.each { field ->
 
-            if (field && ((field?.dwcTerm && !(!includeRaw && field.dwcTerm.contains("_raw"))) || (((grailsApplication.config.downloads.customOnlyIncludeDwC?:'true') == 'false') && !(!includeRaw && field.name.contains("_raw"))))) {
+            if (field && ((field?.dwcTerm && !(!includeRaw && field.dwcTerm.contains("_raw"))) || ((!(grailsApplication.config.downloads.customOnlyIncludeDwC?:'true').toBoolean()) && !(!includeRaw && field.name.contains("_raw"))))) {
                 // only includes "_raw" fields when 'includeRaw' is true
                 String classsName = field?.classs ?: "Misc"
                 String key = classLookup.get(classsName) ?: "Misc"

--- a/grails-app/services/au/org/ala/downloads/BiocacheService.groovy
+++ b/grails-app/services/au/org/ala/downloads/BiocacheService.groovy
@@ -86,7 +86,7 @@ class BiocacheService {
 
         fields.each { field ->
 
-            if (field && field?.dwcTerm && !(!includeRaw && field.dwcTerm.contains("_raw"))) {
+            if (field && ((field?.dwcTerm && !(!includeRaw && field.dwcTerm.contains("_raw"))) || (((grailsApplication.config.downloads.customOnlyIncludeDwC?:'true') == 'false') && !(!includeRaw && field.name.contains("_raw"))))) {
                 // only includes "_raw" fields when 'includeRaw' is true
                 String classsName = field?.classs ?: "Misc"
                 String key = classLookup.get(classsName) ?: "Misc"


### PR DESCRIPTION
The original logic only allowed DwC fields to be included, which is not an obvious filter from the interface.

This allows a new optional config option to allow non-DwC fields to also be included in the custom download:
downloads.customOnlyIncludeDwC=true|false (default true, to replicate existing functionality)