### PR TITLE
#46 Disabled shapefile download option

### DIFF
--- a/grails-app/conf/plugin.groovy
+++ b/grails-app/conf/plugin.groovy
@@ -93,3 +93,6 @@ downloads.gaCustomData = true  // Google Analytics custom dimensions data - set 
 
 doiService.baseUrl = "https://doi.ala.org.au"
 doiService.doiResolverUrl = "https://doi.org/"
+
+filetype.shapefile.disable = true // comment-out to revert to previous behaviour - will probably/eventually be deprecated in biocache-service
+shapefile.kb.url = "https://support.ala.org.au/support/solutions/articles/6000226357"

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -53,6 +53,7 @@ helpicon.csv=<i class="fa fa-question-circle tooltips" data-content="Comma Separ
 type.tsv=TSV
 helpicon.tsv=<i class="fa fa-question-circle tooltips" data-content="Tab Separated Values"></i>
 type.shapefile=Shapefile 
+type.shapefile.disabled=Shapefile - this option no longer available (<a href=''{0}'' target='support'>see explanation</a>)
 helpicon.shapefile=<i class="fa fa-question-circle tooltips" data-content="Vector-based GIS export format"></i>
 
 logger.download.reason.conservation=Conservation management / planning

--- a/grails-app/views/download/options1.gsp
+++ b/grails-app/views/download/options1.gsp
@@ -127,13 +127,27 @@
                                             </label>
                                             <div class="col-sm-8 radio">
                                                 <g:each in="${au.org.ala.downloads.FileType.values()}" var="ft">
+%{--                                                %{-- Skip Shapefile type --}%
+                                                    <g:if test="${!(grailsApplication.config.getProperty("filetype.shapefile.disable") && ft.type == au.org.ala.downloads.FileType.SHAPE.type )}">
+                                                        <div class="">
+                                                            <label>
+                                                                <input id="fileType_${ft.type}" type="radio" name="fileType" class=""
+                                                                       value="${ft.type}" ${(ft.ordinal() == 0) ? 'checked' : ''}/>
+                                                                <g:message code="type.${ft.type}"/> <g:message
+                                                                        code="helpicon.${ft.type}" default=""/>
+                                                            </label>
+                                                        </div>
+                                                    </g:if>
+                                                </g:each>
+                                                <g:if test="${grailsApplication.config.getProperty("filetype.shapefile.disable")}">
+                                                    %{-- Indicate shapefile is deprecated and will be removed --}%
                                                     <div class="">
                                                         <label>
-                                                            <input id="fileType" type="radio" name="fileType" class="" value="${ft.type}" ${(ft.ordinal() == 0)?'checked':''}/>
-                                                            <g:message code="type.${ft.type}"/> <g:message code="helpicon.${ft.type}" default=""/>
+                                                            <input type="radio" name="fileType" value="shapefile" disabled="disabled" />
+                                                            <span style="opacity: 0.8;"><g:message code="type.shapefile.disabled" args="[ grailsApplication.config.getProperty('shapefile.kb.url') ]" /></span>
                                                         </label>
                                                     </div>
-                                                </g:each>
+                                                </g:if>
                                             </div>
                                         </div>
                                     </form>

--- a/src/main/groovy/au/org/ala/downloads/FileType.groovy
+++ b/src/main/groovy/au/org/ala/downloads/FileType.groovy
@@ -24,6 +24,7 @@ import groovy.util.logging.Slf4j
 enum FileType {
     CSV("csv"),
     TSV("tsv"),
+    @Deprecated
     SHAPE("shapefile")
 
     String type


### PR DESCRIPTION
Tested with config option `filetype.shapefile.disable` set as `true` and comment-out and confirmed when commented-out, the form shows the previous "active" shapefile option but when "active" shows the disabled version. 