### PR TITLE
updating fieldguide generation webService POST requests to exclude ap…

### DIFF
--- a/grails-app/services/au/org/ala/downloads/DownloadService.groovy
+++ b/grails-app/services/au/org/ala/downloads/DownloadService.groovy
@@ -14,6 +14,7 @@
 package au.org.ala.downloads
 
 import grails.plugin.cache.Cacheable
+import org.apache.http.entity.ContentType
 import org.grails.web.util.WebUtils
 
 import java.text.SimpleDateFormat
@@ -167,7 +168,7 @@ class DownloadService {
         String url = grailsApplication.config.downloads.fieldguideDownloadUrl + '/generate/offline'
 
         //detect fieldguide vs biocache-hub url. fieldguide url returns 400 when missing email parameter
-        if (webService.post(url, null)?.statusCode != 400) {
+        if (webService.post(url, null, [:], ContentType.APPLICATION_JSON, false, false)?.statusCode != 400) {
             null
         } else {
             def resp = fieldGuideRequest(params)
@@ -216,7 +217,7 @@ class DownloadService {
             fg.link = serverName + contextPath + "/occurrences/search" + requestParams.replaceAll("flimit=[0-9]+|facets=[a-zA-Z_]+","")
 
             try {
-                def response = webService.post(grailsApplication.config.downloads.fieldguideDownloadUrl + "/generate/offline" + params, fg)
+                def response = webService.post(grailsApplication.config.downloads.fieldguideDownloadUrl + "/generate/offline" + params, fg, [:], ContentType.APPLICATION_JSON, false, false)
 
                 if (response?.resp) {
                     //response data


### PR DESCRIPTION
…ikey, userinfo, or JWT against OIDC version of fieldguide since the endpoint is not protected

Required for usage against fieldguide >= Grails4 and ala-ws-plugin >= 3.1.2  i.e. https://fieldguide-test.ala.org.au  
